### PR TITLE
fix: module not found error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const github = require("@actions/github");
 const core = require("@actions/core");
-const { getSlackMessageId } = require("../utils");
+const { getSlackMessageId } = require("./utils");
 
 const {
   createInitialMessage,


### PR DESCRIPTION
In `index.js`, the `utils` module was imported as `../utils` instead of `./utils` which lead to a module not found error when `getSlackMessageId` was called