### PR TITLE
Handle PR Review Dismissals

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { handleCommitPush } from "./actions/handleCommitPush";
 import { handlePullRequestReview } from "./actions/handlePullRequestReview";
 
 const run = async (): Promise<void> => {
-  const { eventName, payload, ref } = github.context;
+  const { action, eventName, payload, ref } = github.context;
   const baseBranch = core.getInput("base-branch");
   const isActingOnBaseBranch = ref.includes(baseBranch);
 
@@ -58,8 +58,11 @@ const run = async (): Promise<void> => {
     return;
   }
 
-  // push of commit
-  if (eventName === "push") {
+  // push of commit / review dismissed
+  if (
+    eventName === "push" ||
+    (eventName === "pull_request_review" && action === "dismissed")
+  ) {
     // merge of PR to base branch
     if (isActingOnBaseBranch) {
       console.log("running handleMerge::: ", payload);


### PR DESCRIPTION
* We want the Slack notify action to notify when new code is committed to a PR that has been reviewed, but when you have it set up to just run `on.push` without any branches defined, we consistently see the initial failure from any pushes made _before_ the PR was opened.

<img width="732" alt="image" src="https://github.com/mlg87/pr-reviewer-slack-notify-action/assets/20176088/69b6a30c-ee60-4eb7-930f-8ebe8c3172fb">

---
* This change should enable you to maintain the `new code has been committed` notifications, while preventing the initial push errors by restricting the `on.push.branches` trigger to your base branch.
```
on:
  pull_request:
    types: [opened, ready_for_review, synchronize]
  pull_request_review:
    types: [submitted, dismissed]
  push:
    branches:
      - 'staging'
```