### PR TITLE
fix (clearReactions): silent no_reaction failures

### DIFF
--- a/src/utils/clearReactions.ts
+++ b/src/utils/clearReactions.ts
@@ -2,9 +2,10 @@ import * as core from "@actions/core";
 import { fail } from "./fail";
 import { logger } from "./logger";
 import { slackWebClient } from "./slackWebClient";
+import { WebAPIPlatformError } from "@slack/web-api";
 
 export const clearReactions = async (slackMessageId: string) => {
-  logger.info(`START clearReactions: ${slackMessageId}`)
+  logger.info(`START clearReactions: ${slackMessageId}`);
   try {
     const channelId = core.getInput("channel-id");
 
@@ -27,9 +28,15 @@ export const clearReactions = async (slackMessageId: string) => {
       }
     }
 
-    logger.info('END clearReactions')
+    logger.info("END clearReactions");
     return;
   } catch (error) {
+    if ((error as WebAPIPlatformError)?.data?.error === "no_reaction") {
+      // Fail silently
+      logger.info(`END clearReactions with error: ${JSON.stringify(error)}`);
+      return;
+    }
+
     fail(error);
     throw error;
   }


### PR DESCRIPTION
Sometimes Slack can't handle clearing reactions, so this will prevent the `no_reaction` error from blocking the more important methods like posting the `new code has been committed` and `This PR has been merged` messages.

<img width="1376" alt="image" src="https://github.com/mlg87/pr-reviewer-slack-notify-action/assets/20176088/aed01b87-50df-470a-9e57-c782d6c00822">
